### PR TITLE
Minor editorial issues on the cumulative charter text

### DIFF
--- a/explainer.html
+++ b/explainer.html
@@ -224,38 +224,24 @@ XML&nbsp;[[xmldsig-core1]]. For an RDF Dataset <span class='rdf'>R</span> this
 implies two steps:
     </p>
 
-    <ol id=sign>
+    <ol>
       <li>
 use an <a href="#canonicalization">RDF Dataset Canonicalization</a> function
 <span class='rdf'>C</span> to calculate <span class='rdf'>C(R)</span>;
       </li>
       <li>
-apply a digital signature function on <span class='rdf'>C(R)</span>.
+        serialize <span class='rdf'>C(R)</span> to quads&nbsp;[[n-quads]] and sort the
+        resulting set of quads;
+      </li>
+      <li id=hash>
+        apply a (traditional) hashing function <span class='rdf'>h</span> on the result
+        of the serialization to yield <span class='rdf'>h(R)</span> (the cryptographic hash of the Dataset). 
+      </li>
+      <li d=sign>
+apply a digital signature function on <span class='rdf'>h(R)</span>.
       </li>
     </ol>
 
-    <p>
-Whereas step (2) may rely on well documented methods, standards, and libraries
-developed by the cryptography community, step (1) requires more complex steps:
-    </p>
-
-    <ol id=hash type="i">
-      <li>
-use an <a href="#canonicalization">RDF Dataset Canonicalization function</a>
-<span class='rdf'>C</span>&nbsp; to generate the canonical form <span
-class='rdf'>C(R)</span>;
-      </li>
-
-      <li>
-serialize <span class='rdf'>C(R)</span> to quads&nbsp;[[n-quads]] and sort the
-resulting set of quads;
-      </li>
-
-      <li>
-apply a (traditional) hashing function <span class='rdf'>h</span> on the result
-of the serialization to yield <span class='rdf'>h(C(R))</span>.
-      </li>
-    </ol>
 
     <p>
 The main challenge for the Working Group is to provide a standard for the <a

--- a/index.html
+++ b/index.html
@@ -361,8 +361,8 @@ Blank Nodes</a>, Aidan Hogan, ACM Trans. Web, vol. 11, no. 4, p. 22:1-22:62,
 2017.
               </li>
             </ol>
-            <p class="milestone" class='todo'>
-<b>Expected completion:</b> <span class=todo>WG-START + 24 months</span>.
+            <p class="milestone">
+<b>Expected completion:</b> WG-START + 24 months.
             </p>
           </dd>
           <dt id="signatures" class="spec">Linked Data Security (LDS)</dt>
@@ -380,8 +380,8 @@ enables a 3rd party to verify the digital proof.
 href="https://w3c-ccg.github.io/ld-proofs/">Linked Data Proofs 1.0</a>, eds.
 Dave Longley, Manu Sporny, W3C Draft Community Group Report, 2020.
             </p>
-            <p class="milestone" class='todo'>
-<b>Expected completion:</b> <span class=todo>WG-START + 24 months</span>.
+            <p class="milestone">
+<b>Expected completion:</b> WG-START + 24 months.
             </p>
           </dd>
           <dt id="vocabulary" class="spec">
@@ -401,8 +401,8 @@ href="https://w3c-ccg.github.io/security-vocab/">The Security Vocabulary</a>,
 ed. Manu Sporny, Orie Steele, Tobias Looker, W3C Draft Community Group Report,
 2020.
             </p>
-            <p class="milestone" class='todo'>
-<b>Expected completion:</b> <span class=todo>WG-START + 24 months</span>.
+            <p class="milestone">
+<b>Expected completion:</b> WG-START + 24 months.
             </p>
           </dd>
         </dl>

--- a/index.html
+++ b/index.html
@@ -177,9 +177,8 @@ vocabularies for encoding digital proofs, such as <a
 href='https://en.wikipedia.org/wiki/Digital_signature'>digital signatures</a>,
 that secure information expressed in serializations such as
 <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a>,
-<a href="https://www.w3.org/TR/turtle/">Turtle</a>,
 <a href="https://www.w3.org/TR/trig/">TriG</a>, and
-<a href="https://www.w3.org/TR/n-quads/">N-QUADS</a>.
+<a href="https://www.w3.org/TR/n-quads/">N-Quads</a>.
     </p>
 
     <section id="details">
@@ -268,9 +267,9 @@ is required.
 
       <p>
 The scope of this Working Group is to define standards to <a
-href="#canonicalization">canonicalize</a>, <a
-href="https://en.wikipedia.org/wiki/Cryptographic_hash_function">
-cryptographically hash</a>, and <a href='explainer.html#sign'>digitally sign</a>
+href="./explainer.html#canonicalization">canonicalize</a>, <a
+href="./explainer.html#hash">
+cryptographically hash</a>, and <a href='./explainer.html#sign'>digitally sign</a>
 an <a href="https://www.w3.org/TR/rdf11-concepts/#section-dataset">RDF
 Dataset</a>. This includes the definition of a standard <a
 href='./explainer.html#canonicalization'>canonicalization algorithm</a>, a
@@ -294,8 +293,8 @@ group:
 
         <ul>
           <li>
-<em>Definition of new cryptographic signature or encryption algorithms such as
-RSA, ECDSA, EdDSA, and AES.</em> This Working Group will only define usage of,
+Definition of new cryptographic signature or encryption algorithms such as
+RSA, ECDSA, EdDSA, and AES. This Working Group will only define usage of,
 and suitable terms to <em>identify</em>, such algorithms. The Working Group will
 also define terms for the input and output parameters to those algorithms that
 the community has developed, or will develop in future.
@@ -341,7 +340,7 @@ Dataset.
 
             <p class="draft-status">
 <b>Draft State</b> to be adopted from: <a
-href="https://json-ld.github.io/rdf-dataset-canonicalization/">RDF Dataset
+href="https://json-ld.github.io/rdf-dataset-canonicalization/spec/index.html">RDF Dataset
 Canonicalization</a>, eds. Dave Longley, Manu Sporny, W3C Draft Community Group
 Report, 2019.
             </p>
@@ -378,7 +377,7 @@ enables a 3rd party to verify the digital proof.
             </p>
             <p class="draft-status">
 <b>Draft State</b> to be adopted from: <a
-href="https://w3c-ccg.github.io/ld-security/">Linked Data Security 1.0</a>, eds.
+href="https://w3c-ccg.github.io/ld-proofs/">Linked Data Proofs 1.0</a>, eds.
 Dave Longley, Manu Sporny, W3C Draft Community Group Report, 2020.
             </p>
             <p class="milestone" class='todo'>


### PR DESCRIPTION
- removed Turtle and kept only TriG for the mission (to make it shorter)
- proper capitalization of n-quads
- link systematically to the explainer in the scope's second paragraph (needed some minor re-structuring of the explainer, too)
- updated the link to the rdf dataset canonicalization draft
- the link https://w3c-ccg.github.io/ld-security/ (Linked Data Security 1.0) was 404. I _think_ the replacement is https://w3c-ccg.github.io/ld-proofs/ Linked Data Proofs 1.0. (@msporny, is that correct?)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/iherman/ld-signatures-charter/pull/17.html" title="Last updated on Mar 29, 2021, 2:28 PM UTC (a77fa09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/iherman/ld-signatures-charter/17/13c439d...a77fa09.html" title="Last updated on Mar 29, 2021, 2:28 PM UTC (a77fa09)">Diff</a>