### PR TITLE
Fix link to WG homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@ interoperability can be verified by passing open test suites.</p>
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="">RDF Dataset Canonicalization and Hash Working Group home page.</a>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/groups/wg/rch/">RDF Dataset Canonicalization and Hash Working Group home page.</a>
         </p>
         <p>
           Most RDF Dataset Canonicalization and Hash Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rch-wg-charter/pull/112.html" title="Last updated on Dec 11, 2024, 3:00 PM UTC (40976b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rch-wg-charter/112/66d6ecb...40976b0.html" title="Last updated on Dec 11, 2024, 3:00 PM UTC (40976b0)">Diff</a>